### PR TITLE
video: HLG HDR mode with hdr=3

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -22,7 +22,7 @@ hdmi_limited=0         ; 1 - use limited (16..235) color range over HDMI
 direct_video=0         ; 1 - enable core video timing over HDMI, use only with VGA converters.
 hdr=0                  ; 1 - enable HDR using the BT2020 color space (faux-HDR, use color controls to tweak).
                        ; 2 - enable HDR using the DCI P3 color space.
-                       ; 3 - enable HDR without color space conversion.
+                       ; 3 - enable HDR using HLG mode.
 fb_size=0              ; 0 - automatic, 1 - full size, 2 - 1/2 of resolution, 4 - 1/4 of resolution.
 fb_terminal=1          ; 1 - enabled (default), 0 - disabled
 osd_timeout=30         ; 5-3600 timeout (in seconds) for OSD to disappear in Menu core. 0 - never timeout.

--- a/video.cpp
+++ b/video.cpp
@@ -1487,12 +1487,13 @@ static void hdmi_config_set_hdr()
 	// MaxFALL: 250cd/m2 (this value does not matter much -
 	// in essence it means that the display should expect -
 	// 25% of the image to be 1000cd/m2)
+	// If HDR == 3, use HLG instead
 	uint8_t hdr_data[] = {
 		0x87,
 		0x01,
 		0x1a,
-		0x28,
-		0x02,
+		(cfg.hdr == 3 ? uint8_t(0x27) : uint8_t(0x28)),
+		(cfg.hdr == 3 ? uint8_t(0x03) : uint8_t(0x02)),
 		0x48,
 		0x8a,
 		0x08,


### PR DESCRIPTION
* Replace HDR metadata with one correctly tuned for BT2020

* Add HLG HDR mode for hdr=3, by request of Mathieulh